### PR TITLE
Plugin that sets date from a Chef-Guard time url.

### DIFF
--- a/cloudbaseinit/plugins/windows/setdate.py
+++ b/cloudbaseinit/plugins/windows/setdate.py
@@ -40,7 +40,8 @@ LOG = logging.getLogger(__name__)
 class SetDatePlugin(base.BasePlugin):
     def execute(self, service, shared_data):
         if CONF.set_date_url is None:
-            return
+            LOG.info('No date_url set, cannot set date')
+            return (base.PLUGIN_EXECUTE_ON_NEXT_BOOT, False)
         url = CONF.set_date_url
         date_format = '%d %B %Y %H:%M:%S'
         LOG.info('Fetching date from: %s' % url)


### PR DESCRIPTION
Hey folks,

We're happily starting to use cloudbase-init with cloudstack, Chef and Chef-Guard ( http://xanzy.io/projects/chef-guard/introduction/overview.html ). We don't want to use the ntp plugin because our chef recipes configure systems to figure out the NTP server to sync with that's in our domain, etc etc.

Hence a small little plugin that can assist with that.
