### PR TITLE
Keeps full content path to network_config file 

### DIFF
--- a/cloudbaseinit/metadata/services/baseopenstackservice.py
+++ b/cloudbaseinit/metadata/services/baseopenstackservice.py
@@ -74,7 +74,7 @@ class BaseOpenStackService(base.BaseMetadataService):
         if key not in network_config:
             return None
 
-        content_name = network_config[key].rsplit("/", 1)[-1]
+        content_name = network_config[key].split("/", 2)[-1]
         content = self.get_content(content_name)
         content = encoding.get_as_string(content)
 


### PR DESCRIPTION
Using the previous method, only the last item after the last "/" was returned.  

The get_content method prepends "openstack" + "/" + "content" + "/" to the path, so the subdirectory path and its contents should be passed in.

For example with the following JSON:

{
    "uuid": "fake-UUID",
    "hostname": "fakehost",
    "network_config":{
        "content_path": "/content/0000/network_config"
        }
}

The updated method reads content from /openstack/content/0000/network_config rather than trying to read it from /openstack/content/network_config.

This change makes the directory structure more true to form.
