### PR TITLE
Added redundancy when getting metadata.

### DIFF
--- a/cloudbaseinit/metadata/services/maasservice.py
+++ b/cloudbaseinit/metadata/services/maasservice.py
@@ -66,9 +66,20 @@ class MaaSHttpService(base.BaseMetadataService):
                           CONF.maas_metadata_url)
         return False
 
-    def _get_response(self, req):
+    def _ensure_network_up(self, request):
+        while True:
+            try:
+                response = request.urlopen(request)
+                return response
+            except socket.error:
+                LOG.debug("socket error while trying to get a response, network most likely down.")
+                pass
+            except Exception as e:
+                raise e
+
+    def _get_response(req):
         try:
-            return request.urlopen(req)
+            return self._ensure_network_up(req)
         except error.HTTPError as ex:
             if ex.code == 404:
                 raise base.NotExistingMetadataException()


### PR DESCRIPTION
Added a retry around metadata fetching to make sure
it will try until either the network comes up or maas
deems the node dead.
This might fix https://bugs.launchpad.net/maas/+bug/1424846
