### PR TITLE
changing load order of metadata services, prioritizing configdrive

### DIFF
--- a/cloudbaseinit/metadata/factory.py
+++ b/cloudbaseinit/metadata/factory.py
@@ -22,8 +22,8 @@ opts = [
     cfg.ListOpt(
         'metadata_services',
         default=[
-            'cloudbaseinit.metadata.services.httpservice.HttpService',
             'cloudbaseinit.metadata.services.configdrive.ConfigDriveService',
+            'cloudbaseinit.metadata.services.httpservice.HttpService',
             'cloudbaseinit.metadata.services.ec2service.EC2Service',
             'cloudbaseinit.metadata.services.maasservice.MaaSHttpService',
             'cloudbaseinit.metadata.services.cloudstack.CloudStack',


### PR DESCRIPTION
In environments with some sites having configdrive (and no http), and other sites don't, the default priority of http metadata service would cause a delay of over 5 minutes before cloudbase-init finalizes the configuration of network and drive extending. 

Changing the order to detect configdrive first and then http (if no config drive found), resolves this issue, and allows for one image to work both in platforms with and without http metadata services enabled.
