### PR TITLE
Fix IPv6-only deployment

### DIFF
--- a/cloudbaseinit/plugins/common/networkconfig.py
+++ b/cloudbaseinit/plugins/common/networkconfig.py
@@ -145,24 +145,27 @@ class NetworkConfigPlugin(plugin_base.BasePlugin):
             if not nic:
                 LOG.warn("Missing details for adapter %s", mac)
                 continue
-            LOG.info("Configuring network adapter %s", mac)
-            reboot = osutils.set_static_network_config(
-                mac,
-                nic.address,
-                nic.netmask,
-                nic.broadcast,
-                nic.gateway,
-                nic.dnsnameservers
-            )
-            reboot_required = reboot or reboot_required
-            # Set v6 info too if available.
+            if nic.address and nic.netmask:
+                LOG.info("Configuring network adapter for IPv4: %s", mac)
+                reboot = osutils.set_static_network_config(
+                    mac,
+                    nic.address,
+                    nic.netmask,
+                    nic.broadcast,
+                    nic.gateway,
+                    nic.dnsnameservers
+                )
+                reboot_required = reboot or reboot_required
             if nic.address6 and nic.netmask6:
+                LOG.info("Configuring network adapter for IPv6: %s", mac)
                 osutils.set_static_network_config_v6(
                     mac,
                     nic.address6,
                     nic.netmask6,
                     nic.gateway6
                 )
+                # Reboot required if no exception from config_v6
+                reboot_required = True
             configured = True
         for mac in macnics:
             LOG.warn("Details not used for adapter %s", mac)

--- a/cloudbaseinit/utils/debiface.py
+++ b/cloudbaseinit/utils/debiface.py
@@ -60,7 +60,8 @@ IFACE_TEMPLATE = dict.fromkeys(FIELDS.keys())
 V6_PROXY = {
     ADDRESS: ADDRESS6,
     NETMASK: NETMASK6,
-    GATEWAY: GATEWAY6
+    GATEWAY: GATEWAY6,
+    MAC:     MAC
 }
 DETAIL_PREPROCESS = {
     MAC: lambda value: value.upper(),


### PR DESCRIPTION
Fixes deploying a system as IPv6-only via the config-drive configuration by storing the mac from the inet6 entry and preventing an IPv4 configuration if no details were passed. Without this IPv6-only will fail due to the mac not being stored (incomplete nic details) and a bad call to set_static_network_config (as no IPv4 details are present).