### PR TITLE
added support for user-data when using AWS

### DIFF
--- a/cloudbaseinit/metadata/services/ec2service.py
+++ b/cloudbaseinit/metadata/services/ec2service.py
@@ -55,6 +55,10 @@ class EC2Service(base.BaseHTTPMetadataService):
         return self._get_cache_data('%s/meta-data/instance-id' %
                                     self._metadata_version, decode=True)
 
+     def get_user_data(self):
+        return self._get_cache_data('%s/user-data' %
+                                    self._metadata_version)                                   
+
     def get_public_keys(self):
         ssh_keys = []
 


### PR DESCRIPTION
For cross platform support I still want to use cloudbase-init without making specific cloud-configs