### PR TITLE
add support to foreman_userdata for Windows build on Foreman

### DIFF
--- a/cloudbaseinit/conf/factory.py
+++ b/cloudbaseinit/conf/factory.py
@@ -22,6 +22,7 @@ _OPT_PATHS = (
     'cloudbaseinit.conf.maas.MAASOptions',
     'cloudbaseinit.conf.openstack.OpenStackOptions',
     'cloudbaseinit.conf.azure.AzureOptions',
+    'cloudbaseinit.conf.foreman.ForemanOptions',
 )
 
 

--- a/cloudbaseinit/conf/foreman.py
+++ b/cloudbaseinit/conf/foreman.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Cloudbase Solutions Srl
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Config options available for the foreman metadata service."""
+
+from oslo_config import cfg
+
+from cloudbaseinit.conf import base as conf_base
+
+
+class ForemanOptions(conf_base.Options):
+
+    """Config options available for the foreman metadata service."""
+
+    def __init__(self, config):
+        super(ForemanOptions, self).__init__(config, group="foreman")
+        self._options = [
+            cfg.StrOpt(
+                "metadata_base_url", default="http://foreman.example.invalid/",
+                help="The base URL where the service looks for metadata",
+                deprecated_name="foreman_metadata_base_url",
+                deprecated_group="DEFAULT"),
+            cfg.BoolOpt(
+                "https_allow_insecure", default=False,
+                help="Whether to disable the validation of HTTPS "
+                     "certificates."),
+            cfg.StrOpt(
+                "https_ca_bundle", default=None,
+                help="The path to a CA_BUNDLE file or directory with "
+                     "certificates of trusted CAs."),
+        ]
+
+    def register(self):
+        """Register the current options to the global ConfigOpts object."""
+        group = cfg.OptGroup(self.group_name, title='Foreman Options')
+        self._config.register_group(group)
+        self._config.register_opts(self._options, group=group)
+
+    def list(self):
+        """Return a list which contains all the available options."""
+        return self._options

--- a/cloudbaseinit/metadata/services/foreman.py
+++ b/cloudbaseinit/metadata/services/foreman.py
@@ -1,0 +1,48 @@
+# Copyright 2014 Cloudbase Solutions Srl
+# Copyright 2012 Mirantis Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_log import log as oslo_logging
+
+from cloudbaseinit import conf as cloudbaseinit_conf
+from cloudbaseinit.metadata.services import base
+from cloudbaseinit.utils import network
+
+CONF = cloudbaseinit_conf.CONF
+LOG = oslo_logging.getLogger(__name__)
+
+
+class Foreman(base.BaseHTTPMetadataService):
+
+    def __init__(self):
+        super(Foreman, self).__init__(
+            base_url=CONF.foreman.metadata_base_url,
+            https_allow_insecure=CONF.foreman.https_allow_insecure,
+            https_ca_bundle=CONF.foreman.https_ca_bundle)
+        self._enable_retry = True
+
+    def load(self):
+        super(Foreman, self).load()
+
+        try:
+            self.get_user_data()
+            return True
+        except Exception as ex:
+            LOG.exception(ex)
+            LOG.debug('Metadata not found at URL \'%s\'' %
+                      CONF.foreman.metadata_base_url)
+            return False
+
+    def get_user_data(self):
+        return self._get_cache_data('userdata/user-data')


### PR DESCRIPTION
This is to add support for building Windows via Foreman and cloudbase-init. There is a foreman plugin called [foreman_userdata](https://github.com/theforeman/foreman_userdata), which serves userdata (cloud-init) templates.