### PR TITLE
Modifies userdata plugin to support jinja templating

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+jinja2
 pbr>=2.0.0
 iso8601
 eventlet


### PR DESCRIPTION
We're working on adding Windows support for Kubernetes cluster-api and it uses cloud-init for bootstrapping with kubeadm. Cloud init relies on jinja to template the user data with values from the instance data (e.g: hostname). 

A sample cloud-init metadata: 
```
## template: jinja
#cloud-config

write_files:
-   path: /tmp/kubeadm-node.yaml
    owner: root:root
    permissions: '0640'
    content: |
      ---
      apiVersion: kubeadm.k8s.io/v1beta1
      discovery:
        bootstrapToken:
          apiServerEndpoint: capi-quickstart-apiserver-748134055.us-east-1.elb.amazonaws.com:6443
          caCertHashes:
          - sha256:1234
          token: some_token
          unsafeSkipCAVerification: false
      kind: JoinConfiguration
      nodeRegistration:
        kubeletExtraArgs:
          cloud-provider: aws
        name: '{{ ds.meta_data.hostname }}'
```

We only exposed the hostname as that was the only thing needed to complete the template above. The cloud providers don't expose much else in the current implementation. To provide all of the metadata across all cloud providers will be a much larger undertaking. 

Note: 
- Didn't modify multipart functionality as it's not required by cluster-api. Looking for feedback on how to proceed. 