### PR TITLE
bond links added MAC to NetConnectionID convertion

### DIFF
--- a/cloudbaseinit/conf/default.py
+++ b/cloudbaseinit/conf/default.py
@@ -144,6 +144,10 @@ class GlobalOptions(conf_base.Options):
                 help='Set the password provided in the configuration. '
                      'If False or no password is provided, a random one '
                      'will be set'),
+            cfg.BoolOpt(
+                'random_user_password', default=True,
+                help='Set a random password if not provided in the configuration. '
+                     'If True, a random one will be set'),
             cfg.StrOpt(
                 'first_logon_behaviour',
                 default=constant.CLEAR_TEXT_INJECTED_ONLY,

--- a/cloudbaseinit/plugins/common/setuserpassword.py
+++ b/cloudbaseinit/plugins/common/setuserpassword.py
@@ -83,13 +83,16 @@ class SetUserPasswordPlugin(base.BasePlugin):
             return None
 
         password, injected = self._get_password(service, shared_data)
-        if not password:
+        if not password and CONF.random_user_password:
             LOG.debug('Generating a random user password')
             password = osutils.generate_random_password(
                 CONF.user_password_length)
-
-        osutils.set_user_password(user_name, password)
-        self._change_logon_behaviour(user_name, password_injected=injected)
+        if password:
+            osutils.set_user_password(user_name, password)
+            LOG.debug("Update user password for user: %s", user_name)
+            self._change_logon_behaviour(user_name, password_injected=injected)
+        else:
+            LOG.debug('no password set, skipping updating password...')
         return password
 
     def _change_logon_behaviour(self, username, password_injected=False):


### PR DESCRIPTION
Hi guys,

In our scenario of setting bond links, MACs are collected without `NetConnectionID`, cause of jobs running on a Debian based PXE OS agent. so we need to do the MAC to NetConnectionID conversion before process_bond_links execution. This PR does this. Are there any better approaches? Any comments are welcomed. 

Thanks!