### PR TITLE
Support getting admin_username from OpenStack metadata

### DIFF
--- a/cloudbaseinit/metadata/services/baseopenstackservice.py
+++ b/cloudbaseinit/metadata/services/baseopenstackservice.py
@@ -249,6 +249,9 @@ class BaseOpenStackService(base.BaseMetadataService):
             services=services
         )
 
+    def get_admin_username(self):
+        return self._get_meta_data().get('meta', {}).get('admin_username')
+
     def get_admin_password(self):
         meta_data = self._get_meta_data()
         meta = meta_data.get('meta')

--- a/cloudbaseinit/tests/metadata/services/test_baseopenstackservice.py
+++ b/cloudbaseinit/tests/metadata/services/test_baseopenstackservice.py
@@ -126,6 +126,27 @@ class TestBaseOpenStackService(unittest.TestCase):
 
     @mock.patch(MODPATH +
                 ".BaseOpenStackService._get_meta_data")
+    def _test_get_admin_username(self, mock_get_meta_data, meta_data):
+        mock_get_meta_data.return_value = meta_data
+        response = self._service.get_admin_username()
+        mock_get_meta_data.assert_called_once_with()
+        if meta_data and 'admin_username' in meta_data.get('meta'):
+            self.assertEqual(meta_data.get('meta')['admin_username'], response)
+        else:
+            self.assertIsNone(response)
+
+    def test_get_admin_username_in_meta(self):
+        self._test_get_admin_username(
+            meta_data={'meta': {'admin_username': 'fake user'}})
+
+    def test_get_admin_username_no_username_in_meta(self):
+        self._test_get_admin_username(meta_data={'meta': {}})
+
+    def test_get_admin_username_no_meta_data(self):
+        self._test_get_admin_username(meta_data={})
+
+    @mock.patch(MODPATH +
+                ".BaseOpenStackService._get_meta_data")
     def _test_get_admin_password(self, mock_get_meta_data, meta_data):
         mock_get_meta_data.return_value = meta_data
         response = self._service.get_admin_password()

--- a/doc/source/services.rst
+++ b/doc/source/services.rst
@@ -49,6 +49,7 @@ Capabilities:
     * public keys
     * `WinRM <https://docs.microsoft.com/en-us/windows/win32/winrm/authentication-for-remote-connections#client-certificate-based-authentication>`_ authentication certificates
     * static network configuration
+    * admin user name
     * admin user password
     * post admin user password (only once)
     * user data
@@ -101,6 +102,7 @@ Capabilities:
     * public keys
     * authentication certificates
     * static network configuration
+    * admin user name
     * admin user password
     * user data
 


### PR DESCRIPTION
I want to have a custom username in a new instance whilst still getting authorized_keys from OpenStack.

This PR reads the default administrator name from a custom meta data key `admin_username`.