### PR TITLE
enable static network configuration via vmware guestinfo

### DIFF
--- a/cloudbaseinit/metadata/services/vmwareguestinfoservice.py
+++ b/cloudbaseinit/metadata/services/vmwareguestinfoservice.py
@@ -25,6 +25,7 @@ from cloudbaseinit import exception
 from cloudbaseinit.metadata.services import base
 from cloudbaseinit.osutils import factory as osutils_factory
 from cloudbaseinit.utils import serialization
+from cloudbaseinit.metadata.services.nocloudservice import NoCloudNetworkConfigV1Parser
 
 CONF = cloudbaseinit_conf.CONF
 LOG = oslo_logging.getLogger(__name__)
@@ -151,3 +152,16 @@ class VMwareGuestInfoService(base.BaseMetadataService):
 
     def get_admin_password(self):
         return self._meta_data.get('admin-password')
+
+    def get_network_details_v2(self):
+        network_data = self._meta_data.get('network')
+        if not network_data:
+            LOG.info("No network configuration found in metadata")
+            return
+        network_data_version = network_data.get("version")
+        if network_data_version != 1:
+            LOG.error("Network data version '%s' is not supported",
+                      network_data_version)
+            return
+        network_config_parser = NoCloudNetworkConfigV1Parser()
+        return network_config_parser.parse(network_data.get("config"))

--- a/cloudbaseinit/metadata/services/vmwareguestinfoservice.py
+++ b/cloudbaseinit/metadata/services/vmwareguestinfoservice.py
@@ -25,7 +25,7 @@ from cloudbaseinit import exception
 from cloudbaseinit.metadata.services import base
 from cloudbaseinit.osutils import factory as osutils_factory
 from cloudbaseinit.utils import serialization
-from cloudbaseinit.metadata.services.nocloudservice import NoCloudNetworkConfigV1Parser
+from cloudbaseinit.metadata.services import nocloudservice
 
 CONF = cloudbaseinit_conf.CONF
 LOG = oslo_logging.getLogger(__name__)
@@ -163,5 +163,5 @@ class VMwareGuestInfoService(base.BaseMetadataService):
             LOG.error("Network data version '%s' is not supported",
                       network_data_version)
             return
-        network_config_parser = NoCloudNetworkConfigV1Parser()
+        network_config_parser = nocloudservice.NoCloudNetworkConfigV1Parser()
         return network_config_parser.parse(network_data.get("config"))

--- a/doc/source/services.rst
+++ b/doc/source/services.rst
@@ -518,6 +518,19 @@ Example metadata in yaml format:
     public-keys-data: |
       ssh-key 1
       ssh-key 2
+    network:
+      version: 1
+      config:
+        - type: physical
+          name: interface0
+          mac_address: "52:54:00:12:34:00"
+          subnets:
+            - type: static
+              address: 192.168.1.10
+              netmask: 255.255.255.0
+              dns_nameservers:
+                - 192.168.1.11
+
 
 This metadata content needs to be set as string in the guestinfo
 dictionary, thus needs to be converted to base64 (it is recommended to
@@ -551,6 +564,9 @@ Capabilities:
     * admin user name
     * admin user password
     * user data
+    * static network configuration (`network config v1
+      <https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v1.html>`_
+      format)
 
 Config options for `vmwareguestinfo` section:
 


### PR DESCRIPTION
Resolves https://github.com/cloudbase/cloudbase-init/issues/78

This enables static networking configuration in the vmware guestinfo metadata source. I basically just have it parse the network data using the nocloud network config v1 parser since they follow the same spec.

I'm a bit green to this codebase so please let me know if there's more I need to add for this to have the intended effect.