### PR TITLE
doc: removed unsupported inline comments

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -51,7 +51,8 @@ services and plugins ready for execution and also customizing user experience.
     # What user to create and in which group(s) to be put.
     username=Admin
     groups=Administrators
-    inject_user_password=true  # Use password from the metadata (not random).
+    # Use password from the metadata (not random).
+    inject_user_password=true
     # Which devices to inspect for a possible configuration drive (metadata).
     config_drive_raw_hhd=true
     config_drive_cdrom=true
@@ -79,7 +80,8 @@ services and plugins ready for execution and also customizing user experience.
     plugins=cloudbaseinit.plugins.common.mtu.MTUPlugin,
             cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin
     # Miscellaneous.
-    allow_reboot=false    # allow the service to reboot the system
+    # allow the service to reboot the system
+    allow_reboot=false
     stop_service_on_exit=false
 
 The "cloudbase-init-unattend.conf" configuration file is similar to the


### PR DESCRIPTION
Due to a non-implementation in `oslo.config`, inline comments in the config files are not currently supported.

I discovered this during my testing of cloudbase-init images in Openstack, here are the logs :

```
2022-11-25 15:25:18.360 1820 ERROR cloudbaseinit.init [-] plugin 'SetUserPasswordPlugin' failed with error 'Value for option inject_user_password from LocationInfo(location=<Locations.user: (4, True)>, detail='C:\\Program Files\\Cloudbase Solutions\\Cloudbase-Init\\conf\\cloudbase-init.conf') is not valid: Unexpected boolean value 'True  # Use password from the metadata (not random).'': oslo_config.cfg.ConfigFileValueError: Value for option inject_user_password from LocationInfo(location=<Locations.user: (4, True)>, detail='C:\\Program Files\\Cloudbase Solutions\\Cloudbase-Init\\conf\\cloudbase-init.conf') is not valid: Unexpected boolean value 'True  # Use password from the metadata (not random).'
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init [-] Value for option inject_user_password from LocationInfo(location=<Locations.user: (4, True)>, detail='C:\\Program Files\\Cloudbase Solutions\\Cloudbase-Init\\conf\\cloudbase-init.conf') is not valid: Unexpected boolean value 'True  # Use password from the metadata (not random).': oslo_config.cfg.ConfigFileValueError: Value for option inject_user_password from LocationInfo(location=<Locations.user: (4, True)>, detail='C:\\Program Files\\Cloudbase Solutions\\Cloudbase-Init\\conf\\cloudbase-init.conf') is not valid: Unexpected boolean value 'True  # Use password from the metadata (not random).'
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init Traceback (most recent call last):
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init   File "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\Python\lib\site-packages\oslo_config\cfg.py", line 2694, in _do_get
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init     return (convert(val), alt_loc)
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init   File "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\Python\lib\site-packages\oslo_config\cfg.py", line 2664, in convert
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init     self._substitute(value, group, namespace), opt)
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init   File "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\Python\lib\site-packages\oslo_config\cfg.py", line 2791, in _convert_value
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init     return opt.type(value)
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init   File "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\Python\lib\site-packages\oslo_config\types.py", line 250, in __call__
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init     raise ValueError('Unexpected boolean value %r' % value)
2022-11-25 15:25:18.439 1820 ERROR cloudbaseinit.init ValueError: Unexpected boolean value 'True  # Use password from the metadata (not random).'
```