### PR TITLE
Workaround for gateway from different subnet (segment)

### DIFF
--- a/cloudbaseinit/osutils/windows.py
+++ b/cloudbaseinit/osutils/windows.py
@@ -994,9 +994,22 @@ class WindowsUtils(base.BaseOSUtils):
                 {"route": existing_route.DestinationPrefix, "name": name})
             existing_route.Delete_()
 
+        defroute = ""
+        if family == AF_INET:
+            defroute = "0.0.0.0/0"
+        elif family == AF_INET6:
+            defroute = "::/0"
+
+        conn.MSFT_NetRoute.create(
+            AddressFamily=family, InterfaceAlias=name,
+            DestinationPrefix=f"{gateway}/32")
+        conn.MSFT_NetRoute.create(
+            AddressFamily=family, InterfaceAlias=name,
+            DestinationPrefix=defroute, NextHop=gateway)
+
         conn.MSFT_NetIPAddress.create(
             AddressFamily=family, InterfaceAlias=name, IPAddress=address,
-            PrefixLength=prefix_len, DefaultGateway=gateway)
+            PrefixLength=prefix_len)
 
     def set_static_network_config(self, name, address, prefix_len_or_netmask,
                                   gateway, dnsnameservers):

--- a/cloudbaseinit/osutils/windows.py
+++ b/cloudbaseinit/osutils/windows.py
@@ -1000,9 +1000,15 @@ class WindowsUtils(base.BaseOSUtils):
         elif family == AF_INET6:
             defroute = "::/0"
 
+        gw_prefix_len = ""
+        if family == AF_INET:
+            gw_prefix_len = "32"
+        elif family == AF_INET6:
+            gw_prefix_len = "128"
+
         conn.MSFT_NetRoute.create(
             AddressFamily=family, InterfaceAlias=name,
-            DestinationPrefix=f"{gateway}/32")
+            DestinationPrefix=f"{gateway}/{gw_prefix_len}")
         conn.MSFT_NetRoute.create(
             AddressFamily=family, InterfaceAlias=name,
             DestinationPrefix=defroute, NextHop=gateway)


### PR DESCRIPTION
This PR fixes "DefaultGateway x.x.x.x is not on the same network segment (subnet) that is defined by the IP address y.y.y.y and PrefixLength 32" error.

Assume we constrained by a tiny IPv4 address pool, thus for efficiency reasons we would like to optimize its usage in way that all available addresses are assigned only to the virtual machines. For example lets say on KVM hypervisor we have 10.0.0.1 as a gateway for virtual machine traffic, and 192.0.2.128/30 as an address pool. Given that, without this patch such setup is not possible due to previously mentioned exception is raised by WMI.

We can workaround this issue by creating all the necessary routes manually - firstly we are declaring that 10.0.0.1 is reachable within L2 segment of this interface, and then define default route with a nexthop of 10.0.0.1. Thus when assigning IPv4 address it is not needed to specify DefaultGateway since appropriate route was already created.

To my opinion it is important fix and will be handy for anyone. I will be grateful if you will accept this patch or propose any solution that solves this case more elegantly.