### PR TITLE
add noclouddrive service to default datasources

### DIFF
--- a/cloudbaseinit/conf/default.py
+++ b/cloudbaseinit/conf/default.py
@@ -163,6 +163,7 @@ class GlobalOptions(conf_base.Options):
                     'cloudbaseinit.metadata.services.httpservice.HttpService',
                     'cloudbaseinit.metadata.services'
                     '.configdrive.ConfigDriveService',
+                    '.nocloudservice.NoCloudConfigDriveService',
                     'cloudbaseinit.metadata.services.ec2service.EC2Service',
                     'cloudbaseinit.metadata.services'
                     '.maasservice.MaaSHttpService',

--- a/cloudbaseinit/conf/default.py
+++ b/cloudbaseinit/conf/default.py
@@ -163,6 +163,7 @@ class GlobalOptions(conf_base.Options):
                     'cloudbaseinit.metadata.services.httpservice.HttpService',
                     'cloudbaseinit.metadata.services'
                     '.configdrive.ConfigDriveService',
+                    'cloudbaseinit.metadata.services'
                     '.nocloudservice.NoCloudConfigDriveService',
                     'cloudbaseinit.metadata.services.ec2service.EC2Service',
                     'cloudbaseinit.metadata.services'


### PR DESCRIPTION
NoCloudDrive should be default. Is used by Proxmox for example.