### PR TITLE
Fix access to cidata drive

### DIFF
--- a/cloudbaseinit/conf/default.py
+++ b/cloudbaseinit/conf/default.py
@@ -163,6 +163,7 @@ class GlobalOptions(conf_base.Options):
                     'cloudbaseinit.metadata.services.httpservice.HttpService',
                     'cloudbaseinit.metadata.services'
                     '.configdrive.ConfigDriveService',
+                    '.nocloudservice.NoCloudConfigDriveService',
                     'cloudbaseinit.metadata.services.ec2service.EC2Service',
                     'cloudbaseinit.metadata.services'
                     '.maasservice.MaaSHttpService',

--- a/cloudbaseinit/conf/default.py
+++ b/cloudbaseinit/conf/default.py
@@ -163,6 +163,7 @@ class GlobalOptions(conf_base.Options):
                     'cloudbaseinit.metadata.services.httpservice.HttpService',
                     'cloudbaseinit.metadata.services'
                     '.configdrive.ConfigDriveService',
+                    'cloudbaseinit.metadata.services'
                     '.nocloudservice.NoCloudConfigDriveService',
                     'cloudbaseinit.metadata.services.ec2service.EC2Service',
                     'cloudbaseinit.metadata.services'

--- a/cloudbaseinit/metadata/services/baseconfigdrive.py
+++ b/cloudbaseinit/metadata/services/baseconfigdrive.py
@@ -67,7 +67,7 @@ class BaseConfigDriveService(base.BaseMetadataService):
         super(BaseConfigDriveService, self).load()
 
         self._preprocess_options()
-        self._mgr = factory.get_config_drive_manager()        
+        self._mgr = factory.get_config_drive_manager()
         found = self._mgr.get_config_drive_files(
             drive_label=self._drive_label,
             metadata_file=self._metadata_file,

--- a/cloudbaseinit/metadata/services/baseconfigdrive.py
+++ b/cloudbaseinit/metadata/services/baseconfigdrive.py
@@ -67,7 +67,7 @@ class BaseConfigDriveService(base.BaseMetadataService):
         super(BaseConfigDriveService, self).load()
 
         self._preprocess_options()
-        self._mgr = factory.get_config_drive_manager()
+        self._mgr = factory.get_config_drive_manager()        
         found = self._mgr.get_config_drive_files(
             drive_label=self._drive_label,
             metadata_file=self._metadata_file,

--- a/cloudbaseinit/metadata/services/osconfigdrive/windows.py
+++ b/cloudbaseinit/metadata/services/osconfigdrive/windows.py
@@ -221,7 +221,8 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
                 return get_config_drive(drive_label, metadata_file)
             else:
                 LOG.info("Irrelevant type %(type)s in %(location)s "
-                         "location; skip", {"type": cd_type, "location": cd_location})
+                         "location; skip", {"type": cd_type,
+                                            "location": cd_location})
         except Exception as exc:
             LOG.warning("Config type %(type)s not found in %(loc)s "
                         "location; Error: '%(err)r'",

--- a/cloudbaseinit/metadata/services/osconfigdrive/windows.py
+++ b/cloudbaseinit/metadata/services/osconfigdrive/windows.py
@@ -55,8 +55,7 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
     def _from_cdfs_filename(self, name):
         return name.lower().replace('_', '-')
 
-    def _meta_data_file_exists(self, drive, metadata_file):        
-
+    def _meta_data_file_exists(self, drive, metadata_file):
         if self._osutils._has_cdfs(drive):
             LOG.debug("Drive %s has cdfs. Respecting upper-case file names when looking for meta-data.")
             metadata_file = self._to_cdfs_filename(metadata_file)
@@ -72,7 +71,7 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
         label = self._osutils.get_volume_label(drive)
         if label and label.lower() == required_drive_label:
             LOG.info('Config Drive found on %s', drive)
-            
+
             if self._meta_data_file_exists(drive, metadata_file):
                 LOG.info('Metadata file found on %s', drive)
                 return True
@@ -170,7 +169,7 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
                 os.rmdir(self.target_path)
                 shutil.copytree(drive_letter, self.target_path)
                 LOG.debug("Renaming local copy of cdfs file names to lower-case.")
-                for file in os.listdir():                    
+                for file in os.listdir():
                     shutil.move(os.path.join(self.target_path, file), os.path.join(self.target_path, self._from_cdfs_filename(file)))
 
                 return True

--- a/cloudbaseinit/metadata/services/osconfigdrive/windows.py
+++ b/cloudbaseinit/metadata/services/osconfigdrive/windows.py
@@ -57,7 +57,8 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
 
     def _meta_data_file_exists(self, drive, metadata_file):
         if self._osutils._has_cdfs(drive):
-            LOG.debug("Drive %s has cdfs. Respecting upper-case file names when looking for meta-data.")
+            LOG.debug("Drive %s has cdfs. Respecting upper-case "
+                "file names when looking for meta-data." % drive)
             metadata_file = self._to_cdfs_filename(metadata_file)
 
         if os.path.exists(os.path.join(drive, metadata_file)):
@@ -169,8 +170,9 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
                 os.rmdir(self.target_path)
                 shutil.copytree(drive_letter, self.target_path)
                 LOG.debug("Renaming local copy of cdfs file names to lower-case.")
-                for file in os.listdir():
-                    shutil.move(os.path.join(self.target_path, file), os.path.join(self.target_path, self._from_cdfs_filename(file)))
+                for file in os.listdir(self.target_path):
+                    shutil.move(os.path.join(self.target_path, file), 
+                        os.path.join(self.target_path, self._from_cdfs_filename(file)))
 
                 return True
 

--- a/cloudbaseinit/metadata/services/osconfigdrive/windows.py
+++ b/cloudbaseinit/metadata/services/osconfigdrive/windows.py
@@ -58,7 +58,7 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
     def _meta_data_file_exists(self, drive, metadata_file):
         if self._osutils._has_cdfs(drive):
             LOG.debug("Drive %s has cdfs. Respecting upper-case "
-                "file names when looking for meta-data." % drive)
+                      "file names when looking for meta-data." % drive)
             metadata_file = self._to_cdfs_filename(metadata_file)
 
         if os.path.exists(os.path.join(drive, metadata_file)):
@@ -80,8 +80,8 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
                 LOG.info('Metadata file could not be found on %s', drive)
         else:
             LOG.info("Looking for a Config Drive with label '%s' on '%s'. "
-                  "Found mismatching label '%s'.",
-                  required_drive_label, drive, label)
+                     "Found mismatching label '%s'.",
+                     required_drive_label, drive, label)
         return False
 
     def _get_iso_file_size(self, device):
@@ -169,11 +169,11 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
                                             metadata_file):
                 os.rmdir(self.target_path)
                 shutil.copytree(drive_letter, self.target_path)
-                LOG.debug("Renaming local copy of cdfs file names to lower-case.")
                 for file in os.listdir(self.target_path):
-                    shutil.move(os.path.join(self.target_path, file), 
-                        os.path.join(self.target_path, self._from_cdfs_filename(file)))
-
+                    shutil.move(
+                        os.path.join(self.target_path, file),
+                        os.path.join(self.target_path,
+                                     self._from_cdfs_filename(file)))
                 return True
 
         return False
@@ -221,8 +221,7 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
                 return get_config_drive(drive_label, metadata_file)
             else:
                 LOG.info("Irrelevant type %(type)s in %(location)s "
-                          "location; skip",
-                          {"type": cd_type, "location": cd_location})
+                         "location; skip", {"type": cd_type, "location": cd_location})
         except Exception as exc:
             LOG.warning("Config type %(type)s not found in %(loc)s "
                         "location; Error: '%(err)r'",
@@ -238,9 +237,9 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
         for cd_type, cd_location in itertools.product(searched_types,
                                                       searched_locations):
             LOG.info('Looking for Config Drive %(type)s in %(location)s '
-                      'with expected label %(drive_label)s',
-                      {"type": cd_type, "location": cd_location,
-                       "drive_label": drive_label})
+                     'with expected label %(drive_label)s',
+                     {"type": cd_type, "location": cd_location,
+                      "drive_label": drive_label})
             if self._get_config_drive_files(drive_label, metadata_file,
                                             cd_type, cd_location):
                 return True

--- a/cloudbaseinit/metadata/services/osconfigdrive/windows.py
+++ b/cloudbaseinit/metadata/services/osconfigdrive/windows.py
@@ -60,7 +60,7 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
             LOG.debug("Drive %s has cdfs. Respecting upper-case file names when looking for meta-data.")
             metadata_file = self._to_cdfs_filename(metadata_file)
 
-        if os.path.exists(os.path.join(drive, metadata_file))
+        if os.path.exists(os.path.join(drive, metadata_file)):
             return True
 
         LOG.debug('%s not found', metadata_file)

--- a/cloudbaseinit/osutils/windows.py
+++ b/cloudbaseinit/osutils/windows.py
@@ -1481,8 +1481,9 @@ class WindowsUtils(base.BaseOSUtils):
         return struct.calcsize("P") == 8
 
     def _has_cdfs(self, drive):
-        (out, err, exit_code) = self.execute_powershell_command("wmic "
-                                                                "logicaldisk get deviceid,filesystem")
+        (out, err, exit_code) =
+        self.execute_powershell_command("wmic logicaldisk "
+                                        "get deviceid,filesystem")
         LOG.info("Checking if drive %s has CDFS filesystem" % drive)
         if exit_code == 0:
             lines = out.decode('ascii').replace('\r\r', '').splitlines()[1:]

--- a/cloudbaseinit/osutils/windows.py
+++ b/cloudbaseinit/osutils/windows.py
@@ -1482,20 +1482,19 @@ class WindowsUtils(base.BaseOSUtils):
 
     def _has_cdfs(self, drive):
         out,err,code = self.execute_powershell_command("wmic logicaldisk get deviceid,filesystem")
+        LOG.info("Checking if drive %s has CDFS filesystem" % drive)
         if code == 0:
             lines = out.decode('ascii').replace('\r\r','').splitlines()[1:] # skip header line
             for line in lines:
                 drive_fs = line.split()
-                LOG.info("Checking drive/fs combination %s/%s" % (drive_fs[0], drive_fs[1]))
+                LOG.info("Found candidate %s with %s" % (drive_fs[0], drive_fs[1]))
 
                 if drive.startswith(drive_fs[0].upper()) and drive_fs[1].upper() == "CDFS":
                     return True
         else:
             raise exception.WindowsCloudbaseInitException(
                         "Could not determine file system of drive %s" % drive)
-
         return False
-
 
     def get_physical_disks(self):
         physical_disks = []

--- a/cloudbaseinit/osutils/windows.py
+++ b/cloudbaseinit/osutils/windows.py
@@ -1481,19 +1481,22 @@ class WindowsUtils(base.BaseOSUtils):
         return struct.calcsize("P") == 8
 
     def _has_cdfs(self, drive):
-        out,err,code = self.execute_powershell_command("wmic logicaldisk get deviceid,filesystem")
+        (out, err, exit_code) = self.execute_powershell_command("wmic "
+                                                                "logicaldisk get deviceid,filesystem")
         LOG.info("Checking if drive %s has CDFS filesystem" % drive)
-        if code == 0:
-            lines = out.decode('ascii').replace('\r\r','').splitlines()[1:] # skip header line
+        if exit_code == 0:
+            lines = out.decode('ascii').replace('\r\r', '').splitlines()[1:]
             for line in lines:
                 drive_fs = line.split()
-                LOG.info("Found candidate %s with %s" % (drive_fs[0], drive_fs[1]))
+                LOG.info("Found candidate %s with %s"
+                         % (drive_fs[0], drive_fs[1]))
 
-                if drive.startswith(drive_fs[0].upper()) and drive_fs[1].upper() == "CDFS":
+                if (drive.startswith(drive_fs[0].upper()) and
+                        drive_fs[1].upper() == "CDFS"):
                     return True
         else:
             raise exception.WindowsCloudbaseInitException(
-                        "Could not determine file system of drive %s" % drive)
+                "Could not determine file system of drive %s" % drive)
         return False
 
     def get_physical_disks(self):
@@ -1697,7 +1700,6 @@ class WindowsUtils(base.BaseOSUtils):
 
         args = [powershell_path, "-command", command]
         return self.execute_process(args, shell=False)
-
 
     def execute_powershell_script(self, script_path, sysnative=True):
         base_dir = self._get_system_dir(sysnative)

--- a/cloudbaseinit/osutils/windows.py
+++ b/cloudbaseinit/osutils/windows.py
@@ -1484,7 +1484,7 @@ class WindowsUtils(base.BaseOSUtils):
         out,err,code = self.execute_powershell_command("wmic logicaldisk get deviceid,filesystem")
         if code == 0:
             lines = out.decode('ascii').replace('\r\r','').splitlines()[1:] # skip header line
-            for line in lines:                
+            for line in lines:
                 drive_fs = line.split()
                 LOG.info("Checking drive/fs combination %s/%s" % (drive_fs[0], drive_fs[1]))
 
@@ -1695,7 +1695,7 @@ class WindowsUtils(base.BaseOSUtils):
         powershell_path = os.path.join(base_dir,
                                        'WindowsPowerShell\\v1.0\\'
                                        'powershell.exe')
-        
+
         args = [powershell_path, "-command", command]
         return self.execute_process(args, shell=False)
 


### PR DESCRIPTION
On Windows, on a CDFS drive, the filenames are shown in upper-case, dashes and spaces replaced with underscores.
This is in line with the specification:
```
The standard also specifies the following name restrictions (sections 7.5 and 7.6):[[4]](https://en.wikipedia.org/wiki/ISO_9660#cite_note-ISO9660-4)

All levels restrict file names in the mandatory file hierarchy to upper case letters, digits, underscores ("_"), and a dot. (See also section 7.4.4 and Annex A.)
```

This becomes a problem here because cloudbase-init assumes in NoCloudConfigDriveService that files
meta-data, network-config, user-data, vendor-data exist on a cdrom/isofs drive.

However, Windows 10 (and most likely other versions of Windows) actually shows the files as
META_DATA, NETWORK_CONFIG, USER_DATA, VENDOR_DATA
and therefore NoCloudConfigDriveService does not find any data source to read.

This PR fixes the issue by renaming file names where appropriate. 