### PR TITLE
use instance_id as string for plugin sections

### DIFF
--- a/cloudbaseinit/init.py
+++ b/cloudbaseinit/init.py
@@ -39,7 +39,7 @@ class InitManager(object):
         if not instance_id:
             return self._PLUGINS_CONFIG_SECTION
         else:
-            return instance_id + "/" + self._PLUGINS_CONFIG_SECTION
+            return ("%s/%s" % (instance_id, self._PLUGINS_CONFIG_SECTION))
 
     def _get_plugin_status(self, osutils, instance_id, plugin_name):
         return osutils.get_config_value(plugin_name,

--- a/cloudbaseinit/tests/test_init.py
+++ b/cloudbaseinit/tests/test_init.py
@@ -60,12 +60,16 @@ class TestInitManager(unittest.TestCase):
         if not instance_id:
             self.assertEqual(self._init._PLUGINS_CONFIG_SECTION, response)
         else:
-            self.assertEqual(
-                instance_id + "/" + self._init._PLUGINS_CONFIG_SECTION,
-                response)
+            expected_response = (
+                "%s/%s" % (instance_id, self._init._PLUGINS_CONFIG_SECTION))
+            self.assertEqual(expected_response, response)
 
     def test_get_plugin_section_id(self):
         fake_id = "100"
+        self._test_get_plugin_section(instance_id=fake_id)
+
+    def test_get_plugin_section_id_int(self):
+        fake_id = 100
         self._test_get_plugin_section(instance_id=fake_id)
 
     def test_get_plugin_section_no_id(self):


### PR DESCRIPTION
If `instance_id` is set in the metadata as an integer, cast it as a string when used to uniquely identify plugin sections.

Change-Id: I3a9335fb3885c5f3191051aaaeeec94f89a6b89a

Fixes: https://github.com/cloudbase/cloudbase-init/issues/124

Currently, we are using review process here: https://review.opendev.org/c/x/cloudbase-init/+/898117, this is just a test PR to see if the github actions work.