### PR TITLE
Add network metadata support for vmware metadata service

### DIFF
--- a/cloudbaseinit/metadata/services/vmwareguestinfoservice.py
+++ b/cloudbaseinit/metadata/services/vmwareguestinfoservice.py
@@ -25,6 +25,7 @@ from cloudbaseinit import exception
 from cloudbaseinit.metadata.services import base
 from cloudbaseinit.osutils import factory as osutils_factory
 from cloudbaseinit.utils import serialization
+from cloudbaseinit.metadata.services.nocloudservice import NoCloudNetworkConfigV1Parser
 
 CONF = cloudbaseinit_conf.CONF
 LOG = oslo_logging.getLogger(__name__)
@@ -151,3 +152,23 @@ class VMwareGuestInfoService(base.BaseMetadataService):
 
     def get_admin_password(self):
         return self._meta_data.get('admin-password')
+    
+    def get_network_details_v2(self):
+        try:
+            raw_data = self._meta_data.get('network-config', decode=True)
+            network_data = serialization.parse_json_yaml(raw_data)
+        except base.NotExistingMetadataException:
+            LOG.info("V2 network metadata not found")
+            return
+        except serialization.YamlParserConfigError:
+            LOG.exception("V2 network metadata could not be deserialized")
+            return
+
+        network_data_version = network_data.get('version')
+        if network_data_version != 1:
+            LOG.error("Network data version '%s' is not supported",
+                      network_data_version)
+            return
+
+        network_config_parser = NoCloudNetworkConfigV1Parser()
+        return network_config_parser.parse(network_data.get("config"))

--- a/cloudbaseinit/metadata/services/vmwareguestinfoservice.py
+++ b/cloudbaseinit/metadata/services/vmwareguestinfoservice.py
@@ -155,7 +155,7 @@ class VMwareGuestInfoService(base.BaseMetadataService):
     
     def get_network_details_v2(self):
         try:
-            raw_data = self._meta_data.get('network-config', decode=True)
+            raw_data = self._meta_data.get('network', decode=True)
             network_data = serialization.parse_json_yaml(raw_data)
         except base.NotExistingMetadataException:
             LOG.info("V2 network metadata not found")


### PR DESCRIPTION
- Added parsing of vmware  metadata as NetworkDetailsV2
- Using NoCloudNetworkConfigV1Parser for parsing the data

Functionality is analog to cloud-init as per https://cloudinit.readthedocs.io/en/latest/reference/datasources/vmware.html#instance-data-and-lazy-networks and https://github.com/canonical/cloud-init/blob/4f60ff099eb0a6f57595706f4d34cf713d3c02b1/cloudinit/sources/DataSourceVMware.py#L275