### PR TITLE
Add support for `administrators_authorized_keys` to `SetUserSSHPublicKeysPlugin` and `UsersPlugin`

### DIFF
--- a/cloudbaseinit/plugins/common/sshpublickeys.py
+++ b/cloudbaseinit/plugins/common/sshpublickeys.py
@@ -25,6 +25,10 @@ from cloudbaseinit.plugins.common import base
 CONF = cloudbaseinit_conf.CONF
 LOG = oslo_logging.getLogger(__name__)
 
+# The default Win32-OpenSSH config assumes that the built-in Administrators
+# group with SID S-1-5-32-544 does not have an internationalized name.
+ADMINISTRATORS = "Administrators"
+
 
 class SetUserSSHPublicKeysPlugin(base.BasePlugin):
 
@@ -49,10 +53,31 @@ class SetUserSSHPublicKeysPlugin(base.BasePlugin):
             os.makedirs(user_ssh_dir)
 
         authorized_keys_path = os.path.join(user_ssh_dir, "authorized_keys")
-        LOG.info("Writing SSH public keys in: %s" % authorized_keys_path)
-        with open(authorized_keys_path, 'w') as f:
-            for public_key in public_keys:
-                # All public keys are space-stripped.
-                f.write(public_key + "\n")
+        authorized_keys_files = [authorized_keys_path]
+
+        admin_membership_conditions = (
+            osutils.group_exists(ADMINISTRATORS),
+            ADMINISTRATORS in CONF.groups
+        )
+
+        if all(admin_membership_conditions):
+            program_data_dir = os.getenv("PROGRAMDATA", "C:\ProgramData")
+            LOG.debug("Program Data: %s" % program_data_dir)
+
+            program_data_ssh_dir = os.path.join(program_data_dir, "ssh")
+            if not os.path.exists(program_data_ssh_dir):
+                os.makedirs(program_data_ssh_dir)
+
+            administrators_authorized_keys_path = os.path.join(
+                program_data_ssh_dir, "administrators_authorized_keys"
+            )
+            authorized_keys_files.append(administrators_authorized_keys_path)
+
+        for filepath in authorized_keys_files:
+            LOG.info("Writing SSH public keys in: %s" % filepath)
+            with open(filepath, 'w') as f:
+                for public_key in public_keys:
+                    # All public keys are space-stripped.
+                    f.write(public_key + "\n")
 
         return base.PLUGIN_EXECUTION_DONE, False


### PR DESCRIPTION
Closes #162.

Adds support for `administrators_authorized_keys` to `SetUserSSHPublicKeysPlugin` and `UsersPlugin`. See <https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagement#administrative-user> for the details.

Please note that the rule from the Win32-OpenSSH configuration only applies to the group that is literally called Administrators. Win32-OpenSSH does not check the system internationalization and does not use security identifiers for group matching.

Therefore, we only check for the presence of a group with the English name used in the Win32-OpenSSH configuration, and do nothing if the group is missing.