### PR TITLE
With nocloud localfolder support

### DIFF
--- a/cloudbaseinit/conf/nocloud.py
+++ b/cloudbaseinit/conf/nocloud.py
@@ -34,6 +34,9 @@ class NoCloudOptions(conf_base.Options):
                 "userdata_file", default="user-data",
                 help="The file name where the service looks for"
                      "userdata"),
+            cfg.StrOpt(
+                "drive_label", default="cidata",
+                help="The path the service looks for metadata"),
         ]
 
     def register(self):

--- a/cloudbaseinit/constant.py
+++ b/cloudbaseinit/constant.py
@@ -16,6 +16,7 @@
 CD_TYPES = {
     "vfat",    # Visible device (with partition table).
     "iso",     # "Raw" format containing ISO bytes.
+    "local",   # Cloud-drive is just a local folder
 }
 CD_LOCATIONS = {
     # Look into optical devices. Only an ISO format could be
@@ -27,6 +28,7 @@ CD_LOCATIONS = {
     # Search through partitions for raw ISO content or through volumes
     # containing configuration drive's content.
     "partition",
+    "local",   # Cloud-drive is just a local folder
 }
 
 POLICY_IGNORE_ALL_FAILURES = "ignoreallfailures"

--- a/cloudbaseinit/metadata/services/nocloudservice.py
+++ b/cloudbaseinit/metadata/services/nocloudservice.py
@@ -659,7 +659,7 @@ class NoCloudConfigDriveService(baseconfigdrive.BaseConfigDriveService):
 
     def __init__(self):
         super(NoCloudConfigDriveService, self).__init__(
-            'cidata', CONF.nocloud.metadata_file,
+            CONF.nocloud.drive_label, CONF.nocloud.metadata_file,
             CONF.nocloud.userdata_file)
         self._meta_data = {}
 

--- a/cloudbaseinit/metadata/services/osconfigdrive/windows.py
+++ b/cloudbaseinit/metadata/services/osconfigdrive/windows.py
@@ -182,6 +182,12 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
                 return True
         return False
 
+    def _get_config_drive_from_local(self, drive_label, metadata_file):
+        os.rmdir(self.target_path)
+        shutil.copytree(drive_label, self.target_path)
+        return True
+
+
     def _get_config_drive_from_volume(self, drive_label, metadata_file):
         """Look through all the volumes for config drive."""
         volumes = self._osutils.get_volumes()
@@ -231,6 +237,7 @@ class WindowsConfigDriveManager(base.BaseConfigDriveManager):
     @property
     def config_drive_type_location(self):
         return {
+            "local_local": self._get_config_drive_from_local,
             "cdrom_iso": self._get_config_drive_from_cdrom_drive,
             "hdd_iso": self._get_config_drive_from_raw_hdd,
             "hdd_vfat": self._get_config_drive_from_vfat,


### PR DESCRIPTION
Nocloud should allow "local file" to be used as datasource.
Current implementation goes up to cloudrive, this PR add a "local" cloud-drive type, and leverage the nocloud/"drive_label" to configure the location of the nocloud metadata folder location


```
    [nocloud]
    drive_label=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf
    [config_drive]
    locations=local
    types=local

```
=> will search for 
meta-data
user-data
and network-config

in C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf folder
