### PR TITLE
requirements: use no-cve urllib3

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -171,7 +171,7 @@ reno===4.1.0
 ncclient===0.6.19
 imagesize===1.4.1
 pydot===4.0.1
-urllib3===2.5.0
+urllib3===2.6.0
 graphviz===0.21
 PyKMIP===0.10.0
 python-observabilityclient===1.2.0


### PR DESCRIPTION
Use `urllib3===2.6.0` instead of `urllib3===2.5.0`.

Error message that appeared with `urllib3===2.5.0`:

```
Found 2 known vulnerabilities in 1 package
Name    Version ID             Fix Versions
------- ------- -------------- ------------
urllib3 2.5.0   CVE-2025-66418 2.6.0
urllib3 2.5.0   CVE-2025-66471 2.6.0
```

Change-Id: I6a3938b6904f9b886eeebaa80ae750bc5c78cc91