### PR TITLE
python: support 3.10 and 3.13 versions

### DIFF
--- a/.github/workflows/cloudbase_init_tests.yml
+++ b/.github/workflows/cloudbase_init_tests.yml
@@ -9,11 +9,11 @@ on: [push, pull_request]
 
 jobs:
   linux-unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.13"]
+        python-version: [ "3.10", "3.12", "3.13"]
         architecture: ["x64"]
 
     steps:
@@ -36,7 +36,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ "3.12", "3.13"]
+        python-version: [ "3.10", "3.12", "3.13"]
         architecture: ["x64", "x86"]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifier =
   Operating System :: OS Independent
   Programming Language :: Python
   Programming Language :: Python :: 3
+  Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.12
   Programming Language :: Python :: 3.13
 


### PR DESCRIPTION
Currently, opendev gates support testing Python version 3.10 and 3.13.

Change the setup.cfg and github gates accordingly.

Change-Id: Id47a3b6c41a7f755df5eaca33f1614fe57fde36b