### PR TITLE
Fix Windows NTP server concatenation

### DIFF
--- a/cloudbaseinit/osutils/windows.py
+++ b/cloudbaseinit/osutils/windows.py
@@ -789,9 +789,9 @@ class WindowsUtils(base.BaseOSUtils):
 
         # Convert the NTP hosts list to a string, in order to pass
         # it to w32tm.
-        ntp_hosts = ",".join(ntp_hosts)
+        ntp_hosts = " ".join(ntp_hosts)
 
-        args = [w32tm_path, '/config', '/manualpeerlist:%s' % ntp_hosts,
+        args = [w32tm_path, '/config', '/manualpeerlist:"%s"' % ntp_hosts,
                 '/syncfromflags:manual', '/update']
 
         (out, err, ret_val) = self.execute_process(args, shell=False)

--- a/cloudbaseinit/tests/osutils/test_windows.py
+++ b/cloudbaseinit/tests/osutils/test_windows.py
@@ -2073,7 +2073,7 @@ class TestWindowsUtils(testutils.CloudbaseInitTestBase):
         mock_get_system32_dir.return_value = fake_base_dir
 
         args = [w32tm_path, '/config',
-                '/manualpeerlist:%s' % ",".join(ntp_hosts),
+                '/manualpeerlist:"%s"' % " ".join(ntp_hosts),
                 '/syncfromflags:manual', '/update']
 
         if ret_val:


### PR DESCRIPTION
Ensure the list of NTP servers is space delimited