### PR TITLE
Fix network config when gateway is outside the address subnet

### DIFF
--- a/cloudbaseinit/osutils/windows.py
+++ b/cloudbaseinit/osutils/windows.py
@@ -1020,7 +1020,29 @@ class WindowsUtils(base.BaseOSUtils):
 
         conn.MSFT_NetIPAddress.create(
             AddressFamily=family, InterfaceAlias=name, IPAddress=address,
-            PrefixLength=prefix_len, DefaultGateway=gateway)
+            PrefixLength=prefix_len)
+
+        if gateway:
+            gw_is_v4 = netaddr.valid_ipv4(gateway)
+            gw_is_v6 = netaddr.valid_ipv6(gateway)
+            addr_is_v4 = (family == AF_INET)
+
+            if (gw_is_v4 and addr_is_v4) or (gw_is_v6 and not addr_is_v4):
+                gw_prefix_len = "32" if gw_is_v4 else "128"
+                defroute = "0.0.0.0/0" if gw_is_v4 else "::/0"
+
+                # Create on-link route to the gateway so it is reachable
+                # even when it is outside the address subnet (e.g. /32).
+                try:
+                    conn.MSFT_NetRoute.create(
+                        AddressFamily=family, InterfaceAlias=name,
+                        DestinationPrefix="%s/%s" % (gateway, gw_prefix_len))
+                except Exception:
+                    pass
+
+                conn.MSFT_NetRoute.create(
+                    AddressFamily=family, InterfaceAlias=name,
+                    DestinationPrefix=defroute, NextHop=gateway)
 
     def set_static_network_config(self, name, address, prefix_len_or_netmask,
                                   gateway, dnsnameservers):


### PR DESCRIPTION
## Summary

When using L3-only / EVPN networking with /32 host addresses (common in modern cloud platforms), the gateway is outside the address subnet. The WMI `MSFT_NetIPAddress.create()` call rejects this with:

```
DefaultGateway 169.254.0.1 is not on the same network segment (subnet)
that is defined by the IP address 10.0.0.0 and PrefixLength 32.
```

This PR fixes the issue by creating routes manually instead of relying on `DefaultGateway` parameter:

1. Assign the IP address **without** `DefaultGateway`
2. Create an on-link host route to the gateway (`/32` for IPv4, `/128` for IPv6)
3. Create the default route (`0.0.0.0/0` or `::/0`) via the gateway

This is equivalent to what Linux cloud-init does with on-link routes:
```
ip route add 169.254.0.1 dev eth0 scope link
ip route add default via 169.254.0.1 dev eth0
```

Additionally, gateway route creation is skipped when the gateway address family does not match the address being configured (e.g. IPv4 gateway with IPv6 address).

## Use case

Our IaaS platform (L3-only, BGP/SRv6) assigns `/32` addresses to VMs with an on-link gateway `169.254.0.1`. The network-config v2 via NoCloud CIDATA:

```yaml
version: 2
ethernets:
  nic0:
    match:
      macaddress: "02:65:71:44:66:94"
    addresses:
      - 10.0.0.0/32
      - 2a0c:6ec0:b00::/96
    routes:
      - to: 0.0.0.0/0
        via: 169.254.0.1
        on-link: true
      - to: ::/0
        via: fe80::1
        on-link: true
```

## Testing

Tested on Windows Server 2025 (build 26100) with cloudbase-init 1.1.6. Before the fix, `NetworkConfigPlugin` fails with the WMI error above. After the fix, IP, gateway, routes, and DNS are all configured correctly.

Closes #166