### PR TITLE
Fix SSH key path for Administrator accounts

### DIFF
--- a/cloudbaseinit/plugins/common/sshpublickeys.py
+++ b/cloudbaseinit/plugins/common/sshpublickeys.py
@@ -13,11 +13,11 @@
 #    under the License.
 
 import os
+import subprocess
 
 from oslo_log import log as oslo_logging
 
 from cloudbaseinit import conf as cloudbaseinit_conf
-from cloudbaseinit import exception
 from cloudbaseinit.osutils import factory as osutils_factory
 from cloudbaseinit.plugins.common import base
 
@@ -28,6 +28,34 @@ LOG = oslo_logging.getLogger(__name__)
 
 class SetUserSSHPublicKeysPlugin(base.BasePlugin):
 
+    @staticmethod
+    def _write_authorized_keys(authorized_keys_path, public_keys):
+        authorized_keys_dir = os.path.dirname(authorized_keys_path)
+        if not os.path.exists(authorized_keys_dir):
+            os.makedirs(authorized_keys_dir)
+
+        LOG.info("Writing SSH public keys in: %s" % authorized_keys_path)
+        with open(authorized_keys_path, 'w') as f:
+            for public_key in public_keys:
+                # All public keys are space-stripped.
+                f.write(public_key + "\n")
+
+    @staticmethod
+    def _set_admin_authorized_keys_acl(authorized_keys_path):
+        """Set ACL on administrators_authorized_keys per Microsoft docs.
+
+        Only SYSTEM and Administrators should have access.
+        """
+        try:
+            subprocess.check_call([
+                "icacls.exe", authorized_keys_path,
+                "/inheritance:r",
+                "/grant", "Administrators:F",
+                "/grant", "SYSTEM:F",
+            ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except Exception:
+            LOG.exception("Failed to set ACL on %s" % authorized_keys_path)
+
     def execute(self, service, shared_data):
         public_keys = service.get_public_keys()
         if not public_keys:
@@ -37,22 +65,28 @@ class SetUserSSHPublicKeysPlugin(base.BasePlugin):
         username = service.get_admin_username() or CONF.username
 
         osutils = osutils_factory.get_os_utils()
-        user_home = osutils.get_user_home(username)
 
+        # For users in the Administrators group, write keys to
+        # C:\ProgramData\ssh\administrators_authorized_keys as per
+        # the default OpenSSH sshd_config Match Group directive.
+        # This path does not require the user profile to exist.
+        if osutils.is_builtin_admin(username):
+            programdata = os.environ.get("ProgramData", r"C:\ProgramData")
+            admin_keys_path = os.path.join(
+                programdata, "ssh", "administrators_authorized_keys")
+            self._write_authorized_keys(admin_keys_path, public_keys)
+            self._set_admin_authorized_keys_acl(admin_keys_path)
+            return base.PLUGIN_EXECUTION_DONE, False
+
+        user_home = osutils.get_user_home(username)
         if not user_home:
-            raise exception.CloudbaseInitException("User profile not found!")
+            LOG.warning("User profile not found for %r, "
+                        "cannot write SSH public keys", username)
+            return base.PLUGIN_EXECUTION_DONE, False
 
         LOG.debug("User home: %s" % user_home)
-
-        user_ssh_dir = os.path.join(user_home, '.ssh')
-        if not os.path.exists(user_ssh_dir):
-            os.makedirs(user_ssh_dir)
-
-        authorized_keys_path = os.path.join(user_ssh_dir, "authorized_keys")
-        LOG.info("Writing SSH public keys in: %s" % authorized_keys_path)
-        with open(authorized_keys_path, 'w') as f:
-            for public_key in public_keys:
-                # All public keys are space-stripped.
-                f.write(public_key + "\n")
+        authorized_keys_path = os.path.join(
+            user_home, '.ssh', 'authorized_keys')
+        self._write_authorized_keys(authorized_keys_path, public_keys)
 
         return base.PLUGIN_EXECUTION_DONE, False


### PR DESCRIPTION
## Summary

Write SSH public keys for the built-in Administrator account to `C:\ProgramData\ssh\administrators_authorized_keys` instead of `C:\Users\Administrator\.ssh\authorized_keys`.

## Problem

The default Windows OpenSSH `sshd_config` contains:

```
Match Group administrators
    AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys
```

This means for admin users, sshd reads keys from the ProgramData path, **not** `~/.ssh/authorized_keys`. The current plugin writes to the wrong location, so SSH key authentication fails for Administrator.

Additionally, `~/.ssh/authorized_keys` requires the user profile to exist. After sysprep, the Administrator profile is not created until first login — the `ProfileList` registry entry is missing, causing `get_user_home()` to fail with "User profile not found!" before any keys can be written.

## Fix

For the built-in Administrator account:
- Write keys to `C:\ProgramData\ssh\administrators_authorized_keys`
- Set ACL per [Microsoft docs](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagement): only `BUILTIN\Administrators` and `NT AUTHORITY\SYSTEM`

This path:
- Always exists (system directory, no user profile needed)
- Is where sshd actually reads admin keys from
- Is where all major cloud providers write admin SSH keys (AWS EC2Launch v2, Azure)

For non-admin users, behavior is unchanged (`~/.ssh/authorized_keys`).

## Testing

Tested on Windows Server 2025 (build 26100) with cloudbase-init 1.1.6 + NoCloud metadata service. SSH key authentication works immediately after first boot without requiring Administrator login.

Closes #162