### PR TITLE
Fix UnboundLocalError for dhcp_addr in get_adapter_addresses

### DIFF
--- a/cloudbaseinit/utils/windows/network.py
+++ b/cloudbaseinit/utils/windows/network.py
@@ -120,6 +120,7 @@ def get_adapter_addresses():
 
                 if dhcp_enabled:
                     if not xp_data_only:
+                        dhcp_addr = None
                         if curr_addr.Flags & iphlpapi.IP_ADAPTER_IPV4_ENABLED:
                             dhcp_addr = curr_addr.Dhcpv4Server
 


### PR DESCRIPTION
## Summary

Fix `UnboundLocalError: cannot access local variable 'dhcp_addr'` in `get_adapter_addresses()` when a network adapter has `DHCP_ENABLED` and `IPV6_ENABLED` flags but not `IPV4_ENABLED`.

## Problem

When iterating network adapters, the code checks `IPV4_ENABLED` to assign `dhcp_addr = curr_addr.Dhcpv4Server`. If `IPV4_ENABLED` is not set, `dhcp_addr` is never initialized, but the subsequent IPv6 check references it:

```python
if ((curr_addr.Flags & iphlpapi.IP_ADAPTER_IPV6_ENABLED) and
    (not dhcp_addr or          # <-- UnboundLocalError
     not dhcp_addr.iSockaddrLength)):
```

This causes `NetworkConfigPlugin` to fail completely, preventing network configuration.

## When this happens

On cloud VMs with vDPA/SR-IOV networking where the adapter may have:
- IPv6 link-local addressing with DHCP enabled (`DHCP_ENABLED` + `IPV6_ENABLED`)
- Static IPv4 configuration (no `IPV4_ENABLED` flag)

Tested on Windows Server 2025 with Mellanox ConnectX vDPA networking on Cloud Hypervisor.

## Fix

Initialize `dhcp_addr = None` before the conditional IPv4/IPv6 assignments.

Signed-off-by: Max Makarov <maxpain@linux.com>