### PR TITLE
Use atexit/signal callbacks to catch windows events and log them

### DIFF
--- a/cloudbaseinit/shell.py
+++ b/cloudbaseinit/shell.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import atexit
+import signal
 import sys
 
 from oslo_log import log as oslo_logging
@@ -28,6 +30,20 @@ LOG = oslo_logging.getLogger(__name__)
 def main():
     CONF(sys.argv[1:])
     logging.setup('cloudbaseinit')
+
+    def atexit_handler():
+        LOG.debug("Process is exiting")
+    try:
+        atexit.register(atexit_handler)
+    except Exception as exc:
+        LOG.exception(exc)
+
+    def on_sigterm_handler(sig, frame):
+        LOG.debug("Process has received sigterm")
+    try:
+        signal.signal(signal.SIGTERM, on_sigterm_handler)
+    except Exception as exc:
+        LOG.exception(exc)
 
     try:
         init.InitManager().configure_host()


### PR DESCRIPTION
There are some corner case scenarios when Windows starts - then cloudbase-init runs and tries to execute its plugins. For example, userdata or local scripts that are running. During the execution of the scripts, there is the chance that a Windows reboot is triggered by, for example, a Windows update process. This triggers a cascade of `WM_ENDSESSION` events sent to the processes that cloudbase-init is a parent of - the userdata scripts that are running. At the same time, `WM_ENDSESSION` is also sent to the `cloudbase-init` process.

The documentation states that if the `WM_ENDSESSION` is not handled and the process has exited, a SIGTERM signal is sent to the process, killing it. If the userdata process is killed, it will exit with exit code 1, and then cloudbase-init can have time, in theory, to set the UserDataPlugin registry key state as executed. Then, after the reboot, the UserDataPlugin will not be executed anymore. In the case that the userdata script code had leveraged the exit codes to reboot, like 1001 or 1003, this corner case behaviour would override this.

This change is to just log events, and not try to fix the behaviour, to ensure in the future that we have more information on the timeline of what is happening and in what order.