### PR TITLE
Add per boot plugins

### DIFF
--- a/cloudbaseinit/conf/default.py
+++ b/cloudbaseinit/conf/default.py
@@ -205,6 +205,12 @@ class GlobalOptions(conf_base.Options):
                 help='List of enabled plugin classes, '
                      'to be executed in the provided order'),
             cfg.ListOpt(
+                'plugins_per_boot',
+                default=[],
+                help='List of enabled plugin classes, '
+                     'to be executed on every boot.'
+                     'This list should be a subset of the enabled plugins'),
+            cfg.ListOpt(
                 'user_data_plugins',
                 default=[
                     'cloudbaseinit.plugins.common.userdataplugins.parthandler.'

--- a/cloudbaseinit/init.py
+++ b/cloudbaseinit/init.py
@@ -51,13 +51,28 @@ class InitManager(object):
 
     def _exec_plugin(self, osutils, service, plugin, instance_id, shared_data):
         plugin_name = plugin.get_name()
+        module_name = plugin.__class__.__module__
+        class_name = plugin.__class__.__qualname__
+        plugin_fqdn = "%s.%s" % (module_name, class_name)
 
+        execute_plugin = True
         reboot_required = None
         success = True
         status = None
         if instance_id is not None:
             status = self._get_plugin_status(osutils, instance_id, plugin_name)
+
         if status == plugins_base.PLUGIN_EXECUTION_DONE:
+            LOG.debug('Plugin \'%s\' was executed in a previous run',
+                      plugin_name)
+            execute_plugin = False
+
+        if plugin_fqdn in CONF.plugins_per_boot:
+            LOG.debug('Plugin \'%s\' is configured to run at every boot',
+                      plugin_name)
+            execute_plugin = True
+
+        if not execute_plugin:
             LOG.debug('Plugin \'%s\' execution already done, skipping',
                       plugin_name)
         else:

--- a/cloudbaseinit/shell.py
+++ b/cloudbaseinit/shell.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import atexit
+import signal
 import sys
 
 from oslo_log import log as oslo_logging
@@ -28,6 +30,20 @@ LOG = oslo_logging.getLogger(__name__)
 def main():
     CONF(sys.argv[1:])
     logging.setup('cloudbaseinit')
+
+    def atexit_handler():
+        LOG.debug("Process is exiting")
+    try:
+        atexit.register(atexit_handler)
+    except Exception as exc:
+        LOG.exception(exc)
+
+    def on_sigterm_handler(sig, frame):
+        LOG.debug("Process has received sigterm")
+    try:
+        signal.signal(signal.SIGTERM, on_sigterm_handler)
+    except Exception as exc:
+        LOG.exception(exc)
 
     try:
         init.InitManager().configure_host()

--- a/cloudbaseinit/tests/test_init.py
+++ b/cloudbaseinit/tests/test_init.py
@@ -89,32 +89,6 @@ class TestInitManager(unittest.TestCase):
         self.osutils.set_config_value.assert_called_once_with(
             'fake plugin', 'status', mock_get_plugins_section())
 
-    @mock.patch('cloudbaseinit.init.InitManager._get_plugin_status')
-    @mock.patch('cloudbaseinit.init.InitManager._set_plugin_status')
-    def _test_exec_plugin(self, status, mock_set_plugin_status,
-                          mock_get_plugin_status):
-        fake_name = 'fake name'
-        self.plugin.get_name.return_value = fake_name
-        self.plugin.execute.return_value = (status, True)
-        mock_get_plugin_status.return_value = status
-
-        response = self._init._exec_plugin(osutils=self.osutils,
-                                           service='fake service',
-                                           plugin=self.plugin,
-                                           instance_id='fake id',
-                                           shared_data='shared data')
-
-        mock_get_plugin_status.assert_called_once_with(self.osutils,
-                                                       'fake id',
-                                                       fake_name)
-        if status is base.PLUGIN_EXECUTE_ON_NEXT_BOOT:
-            self.plugin.execute.assert_called_once_with('fake service',
-                                                        'shared data')
-            mock_set_plugin_status.assert_called_once_with(self.osutils,
-                                                           'fake id',
-                                                           fake_name, status)
-            self.assertTrue(response)
-
     def test_exec_plugin_exception_occurs(self):
         fake_name = 'fake name'
         mock_plugin = mock.MagicMock()
@@ -130,11 +104,58 @@ class TestInitManager(unittest.TestCase):
                                     shared_data='shared data')
         self.assertEqual(expected_logging, snatcher.output[:2])
 
+    @mock.patch('cloudbaseinit.init.InitManager._get_plugin_status')
+    @mock.patch('cloudbaseinit.init.InitManager._set_plugin_status')
+    def _test_exec_plugin(self, status, expected_log,
+                          patched_per_boot_configs,
+                          mock_set_plugin_status,
+                          mock_get_plugin_status):
+        fake_name = 'fake name'
+        self.plugin.get_name.return_value = fake_name
+        self.plugin.execute.return_value = (status, True)
+        self.plugin.__class__.__module__ = fake_name
+        self.plugin.__class__.__qualname__ = fake_name
+        mock_get_plugin_status.return_value = status
+
+        with testutils.ConfPatcher("plugins_per_boot",
+                                   patched_per_boot_configs):
+            with testutils.LogSnatcher('cloudbaseinit.init') as snatcher:
+                response = self._init._exec_plugin(osutils=self.osutils,
+                                                   service='fake service',
+                                                   plugin=self.plugin,
+                                                   instance_id='fake id',
+                                                   shared_data='shared data')
+        self.assertEqual(expected_log, snatcher.output[:2])
+
+        mock_get_plugin_status.assert_called_once_with(self.osutils,
+                                                       'fake id',
+                                                       fake_name)
+        if status is base.PLUGIN_EXECUTE_ON_NEXT_BOOT:
+            self.plugin.execute.assert_called_once_with('fake service',
+                                                        'shared data')
+            mock_set_plugin_status.assert_called_once_with(self.osutils,
+                                                           'fake id',
+                                                           fake_name, status)
+            self.assertTrue(response)
+
+    def test_exec_plugin_execution_done_but_per_boot(self):
+        expected_logging = [
+            "Plugin 'fake name' was executed in a previous run",
+            "Plugin 'fake name' is configured to run at every boot"]
+        self._test_exec_plugin(base.PLUGIN_EXECUTION_DONE,
+                               expected_logging, ["fake name.fake name"])
+
     def test_exec_plugin_execution_done(self):
-        self._test_exec_plugin(base.PLUGIN_EXECUTION_DONE)
+        expected_logging = [
+            "Plugin 'fake name' was executed in a previous run",
+            "Plugin 'fake name' execution already done, skipping"]
+        self._test_exec_plugin(base.PLUGIN_EXECUTION_DONE,
+                               expected_logging, [])
 
     def test_exec_plugin(self):
-        self._test_exec_plugin(base.PLUGIN_EXECUTE_ON_NEXT_BOOT)
+        expected_logging = ["Executing plugin 'fake name'"]
+        self._test_exec_plugin(base.PLUGIN_EXECUTE_ON_NEXT_BOOT,
+                               expected_logging, [])
 
     def _test_check_plugin_os_requirements(self, requirements):
         sys.platform = 'win32'


### PR DESCRIPTION
Add plugins_per_boot config option

The following new configuration option can be set:

```
[DEFAULT]
plugins_per_boot = <comma separated list of plugins>
```

If any enabled plugin is also set in this list, then the
plugin will be executed on every boot, irrespective of the
status.

This feature is useful for operators that need a way to preserve
state between reboots and need idempotent plugins.