### PR TITLE
readme: remove links for the win x86 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@
 Stable:
 
   * (64bit) https://www.cloudbase.it/downloads/CloudbaseInitSetup_Stable_x64.msi
-  * (32bit) https://www.cloudbase.it/downloads/CloudbaseInitSetup_Stable_x86.msi
 
 Beta:
 
   * (64bit) https://www.cloudbase.it/downloads/CloudbaseInitSetup_x64.msi
-  * (32bit) https://www.cloudbase.it/downloads/CloudbaseInitSetup_x86.msi
 
 
 ## Got a question?
 
 Visit http://ask.cloudbase.it/questions/.
+
+## Windows 32 bit support has been discontinued.
+
+The last supported version for 32bit installer is 1.1.8 and it can be
+ downloaded from https://www.cloudbase.it/downloads/CloudbaseInitSetup_1_1_8_x86.msi.


### PR DESCRIPTION
With the PR https://github.com/cloudbase/cloudbase-init/pull/212 being merged, cloudbase-init cannot be any longer built for Windows x86, as the cryptography pip package v50.0.0 has removed the support.

Closes: https://github.com/cloudbase/cloudbase-init/issues/213

Change-Id: I6edff0097b52ea77ba6952278b17f81205f287ee